### PR TITLE
Add a job for testing criteria

### DIFF
--- a/app/jobs/check_criteria_job.rb
+++ b/app/jobs/check_criteria_job.rb
@@ -1,0 +1,53 @@
+class CheckCriteriaJob < ApplicationJob
+  require 'net/http'
+  require 'json'
+  queue_as :default
+
+  def perform(*args)
+    alerts = Alert.all
+
+    alerts.each do |alert| 
+      criteria = alert.criteria.all
+
+      if criteria.size == 1
+        puts "One criteria"
+        if check_criterium(criteria.first) 
+          puts "Singe criterium is true"
+        end
+      elsif criteria.size == 2
+        puts "Two criteria"
+        if check_criterium(criteria.first) && check_criterium(criteria.last)
+          puts "Both criteria are true"
+        end
+      elsif criteria.size == 3
+        puts "Three criteria"
+        if check_criterium(criteria.first) && check_criterium(criteria[1]) && check_criterium(criteria.last)
+          puts "All three criteria are true"
+        end
+      end
+    end
+  end
+
+  private 
+
+  # Create RSI query
+  def check_criterium(criterium)
+    uri = URI("https://www.alphavantage.co/query?function=RSI&symbol=ETH&interval=#{criterium.indicatable.interval}&time_period=#{criterium.indicatable.time_period}&series_type=close&apikey=#{ENV['ALPHAVANTAGE_KEY']}")
+    response = Net::HTTP.get_response(uri)
+
+    if response.is_a?(Net::HTTPSuccess)
+      value = JSON.parse(response.body)["Technical Analysis: RSI"].values[0]["RSI"]
+      case criterium.operand
+      when ">"
+        puts "Greater than"
+        criterium.value > value.to_f
+      when "<"  
+        puts "Less than"
+        criterium.value < value.to_f
+      end
+    else 
+      puts "Error retrieving RSI data from Alphavantage"
+    end 
+  end
+end
+

--- a/test/jobs/check_criteria_job_test.rb
+++ b/test/jobs/check_criteria_job_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CheckCriteriaJobTest < ActiveJob::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
- Loops over all alerts and gets their criteria
- Can only have between 1 and 3 criteria
- Can only choose greater than, less than, equal to
- Checks each criterium using AlphaVantage API whether it has been met
- All criteria must be true in order to trigger an alert (not triggered right now)

Future PR: 

- Update seeds to have 3 alerts that have 1, 2, and 3 criteria for proper testing
- Actually trigger an alert